### PR TITLE
Fix: set mailman admin pass

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -36,10 +36,6 @@ fi
 # Set mailman admin password
 mmsitepass $MAILMAN_ADMINPASS
 
-# Add virtualhost
-linetoadd="add_virtualhost('$MAILMAN_URLHOST', '$MAILMAN_EMAILHOST')"
-grep -q "$linetoadd" /etc/mailman/mm_cfg.py || echo "$linetoadd" >> /etc/mailman/mm_cfg.py
-
 # Fix Postfix settings
 postconf -e mydestination=${MAILMAN_EMAILHOST}
 postconf -e myhostname=${HOSTNAME}

--- a/entry.sh
+++ b/entry.sh
@@ -33,6 +33,13 @@ if [ ! -d /var/lib/mailman/lists/mailman ]; then
     /var/lib/mailman/bin/newlist --quiet --urlhost=$MAILMAN_URLHOST --emailhost=$MAILMAN_EMAILHOST mailman $MAILMAN_ADMINMAIL $MAILMAN_ADMINPASS
 fi
 
+# Set mailman admin password
+mmsitepass $MAILMAN_ADMINPASS
+
+# Add virtualhost
+linetoadd="add_virtualhost('$MAILMAN_URLHOST', '$MAILMAN_EMAILHOST')"
+grep -q "$linetoadd" /etc/mailman/mm_cfg.py || echo "$linetoadd" >> /etc/mailman/mm_cfg.py
+
 # Fix Postfix settings
 postconf -e mydestination=${MAILMAN_EMAILHOST}
 postconf -e myhostname=${HOSTNAME}


### PR DESCRIPTION
Two issues preventing the creation of lists with http://lists.example.org/create are solved by this PR:

1. The site password was not set. `mmsitepass $MAILMAN_ADMINPASS` was added.
2. The virtualhosts were not set. `add_virtualhost('$MAILMAN_URLHOST', '$MAILMAN_EMAILHOST')` was added to mm_cfg.py